### PR TITLE
refine page margin with 4 scalars

### DIFF
--- a/src/Demo/Demo.vue
+++ b/src/Demo/Demo.vue
@@ -10,7 +10,7 @@
       :overlay="overlay"
       :zoom="zoom"
       :page_format_mm="page_format_mm"
-      :page_margins="page_margins"
+      :page_margins="[15, 10, 10, 15]"
       :display="display" />
 
   </div>

--- a/src/DocumentEditor/DocumentEditor.vue
+++ b/src/DocumentEditor/DocumentEditor.vue
@@ -58,7 +58,7 @@ export default {
     // Page margins in CSS
     page_margins: {
       type: Array,
-      default:  () => [10, 15]
+      default:  () => [0, 0, 8, 0]
     },
 
     // Display zoom. Only acts on the screen display
@@ -398,7 +398,7 @@ export default {
           top: "calc("+ top_px +"px + "+ view_padding +"px)",
           width: page_width+"px",
           // "height" is set below
-          padding: (this.page_margins[0] / this.px_in_mm) + "px "+ (this.page_margins[1] / this.px_in_mm) +"px",
+          padding: (this.page_margins[0] / this.px_in_mm) + "px " + (this.page_margins[1] / this.px_in_mm) + "px " + (this.page_margins[2] / this.px_in_mm) + "px " + (this.page_margins[3] / this.px_in_mm) + "px",
           transform: "scale("+ this.zoom +")"
         };
         style[allow_overflow ? "minHeight" : "height"] = page_height+"px";
@@ -467,7 +467,7 @@ export default {
         //const page_clone = page_elt.cloneNode(true);
         page.elt.style = ""; // reset page style for the clone
         page.elt.style.position = "relative";
-        page.elt.style.padding = (this.page_margins[0] / this.px_in_mm) + "px "+ (this.page_margins[1] / this.px_in_mm) +"px";
+        page.elt.style.padding = (this.page_margins[0] / this.px_in_mm) + "px " + (this.page_margins[1] / this.px_in_mm) + "px " + (this.page_margins[2] / this.px_in_mm) + "px " + (this.page_margins[3] / this.px_in_mm) + "px";
         page.elt.style.breakBefore = page_idx ? "page" : "auto";
         page.elt.style.width = "calc("+this.page_format_mm[0] / this.px_in_mm +"px - 2px)";
         page.elt.style.height = "calc("+this.page_format_mm[1] / this.px_in_mm +"px - 2px)";


### PR DESCRIPTION
This pull request includes changes to the `DocumentEditor` and `Demo` components to update the handling of page margins. The changes ensure that margins are consistently applied and correctly formatted.

Changes to page margins:

* [`src/Demo/Demo.vue`](diffhunk://#diff-57e3afea09510ff41dc0311213babc923a7e87385e3ebb2fad6a45f1a6d7ce22L13-R13): Updated the `page_margins` property to use a hardcoded array of values `[15, 10, 10, 15]` instead of a variable.

* [`src/DocumentEditor/DocumentEditor.vue`](diffhunk://#diff-a8f1839cee57d007b1d9d3f99211ab86e7069c772389baf67d95139ca5931b6eL61-R61): Changed the default value of `page_margins` to `[0, 0, 8, 0]` to reflect new margin requirements.

* [`src/DocumentEditor/DocumentEditor.vue`](diffhunk://#diff-a8f1839cee57d007b1d9d3f99211ab86e7069c772389baf67d95139ca5931b6eL401-R401): Modified the padding calculation to include all four margins (top, right, bottom, left) for more precise layout control. [[1]](diffhunk://#diff-a8f1839cee57d007b1d9d3f99211ab86e7069c772389baf67d95139ca5931b6eL401-R401) [[2]](diffhunk://#diff-a8f1839cee57d007b1d9d3f99211ab86e7069c772389baf67d95139ca5931b6eL470-R470)